### PR TITLE
Fix/dsa 870 validate on input event

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@smsdigital/ngx-bootstrap",
-  "version": "5.5.1",
+  "version": "5.5.2-pre.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smsdigital/ngx-bootstrap",
-  "version": "5.5.2-pre.1",
+  "version": "5.5.2",
   "description": "Native Angular Bootstrap Components",
   "private": true,
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smsdigital/ngx-bootstrap",
-  "version": "5.5.1",
+  "version": "5.5.2-pre.1",
   "description": "Native Angular Bootstrap Components",
   "private": true,
   "scripts": {

--- a/src/package.json
+++ b/src/package.json
@@ -4,5 +4,5 @@
     "@angular/core": "*",
     "@angular/common": "*"
   },
-  "version": "5.5.0"
+  "version": "5.5.2"
 }

--- a/src/timepicker/timepicker.component.html
+++ b/src/timepicker/timepicker.component.html
@@ -33,6 +33,7 @@
     <!-- hours -->
     <td class="form-group" [class.has-error]="invalidHours">
       <input type="text" [class.is-invalid]="invalidHours"
+             pattern="[0-9]*"
              class="form-control text-center bs-timepicker-field"
              [placeholder]="hoursPlaceholder"
              maxlength="2"
@@ -42,12 +43,15 @@
              (wheel)="prevDef($event);changeHours(hourStep * wheelSign($event), 'wheel')"
              (keydown.ArrowUp)="changeHours(hourStep, 'key')"
              (keydown.ArrowDown)="changeHours(-hourStep, 'key')"
-             (change)="updateHours($event.target.value)" [attr.aria-label]="labelHours"></td>
+             (change)="updateHours($event.target.value)"
+             (input)="updateHours($event.target.value, false)"
+             [attr.aria-label]="labelHours"></td>
     <!-- divider -->
     <td *ngIf="showMinutes">&nbsp;:&nbsp;</td>
     <!-- minutes -->
     <td class="form-group" *ngIf="showMinutes" [class.has-error]="invalidMinutes">
       <input type="text" [class.is-invalid]="invalidMinutes"
+             pattern="[0-9]*"
              class="form-control text-center bs-timepicker-field"
              [placeholder]="minutesPlaceholder"
              maxlength="2"
@@ -57,13 +61,16 @@
              (wheel)="prevDef($event);changeMinutes(minuteStep * wheelSign($event), 'wheel')"
              (keydown.ArrowUp)="changeMinutes(minuteStep, 'key')"
              (keydown.ArrowDown)="changeMinutes(-minuteStep, 'key')"
-             (change)="updateMinutes($event.target.value)" [attr.aria-label]="labelMinutes">
+             (change)="updateMinutes($event.target.value)"
+             (input)="updateMinutes($event.target.value, false)"
+             [attr.aria-label]="labelMinutes">
     </td>
     <!-- divider -->
     <td *ngIf="showSeconds">&nbsp;:&nbsp;</td>
     <!-- seconds -->
     <td class="form-group" *ngIf="showSeconds" [class.has-error]="invalidSeconds">
       <input type="text" [class.is-invalid]="invalidSeconds"
+             pattern="[0-9]*"
              class="form-control text-center bs-timepicker-field"
              [placeholder]="secondsPlaceholder"
              maxlength="2"
@@ -73,7 +80,9 @@
              (wheel)="prevDef($event);changeSeconds(secondsStep * wheelSign($event), 'wheel')"
              (keydown.ArrowUp)="changeSeconds(secondsStep, 'key')"
              (keydown.ArrowDown)="changeSeconds(-secondsStep, 'key')"
-             (change)="updateSeconds($event.target.value)" [attr.aria-label]="labelSeconds">
+             (change)="updateSeconds($event.target.value)"
+             (input)="updateSeconds($event.target.value, false)"
+             [attr.aria-label]="labelSeconds">
     </td>
     <!-- space between -->
     <td *ngIf="showMeridian">&nbsp;&nbsp;&nbsp;</td>

--- a/src/timepicker/timepicker.component.ts
+++ b/src/timepicker/timepicker.component.ts
@@ -243,8 +243,8 @@ export class TimepickerComponent
     );
   }
 
-  updateHours(hours: string): void {
-    this.resetValidation();
+  updateHours(hours: string, blurred = true): void {
+    this.invalidHours = false;
     this.hours = hours;
 
     const isValid = isHourInputValid(this.hours, this.isPM()) && this.isValidLimit();
@@ -256,12 +256,11 @@ export class TimepickerComponent
 
       return;
     }
-
-    this._updateTime();
+    this._updateTime(blurred);
   }
 
-  updateMinutes(minutes: string) {
-    this.resetValidation();
+  updateMinutes(minutes: string, blurred = true) {
+    this.invalidMinutes = false;
     this.minutes = minutes;
 
     const isValid = isMinuteInputValid(this.minutes) && this.isValidLimit();
@@ -274,11 +273,11 @@ export class TimepickerComponent
       return;
     }
 
-    this._updateTime();
+    this._updateTime(blurred);
   }
 
-  updateSeconds(seconds: string) {
-    this.resetValidation();
+  updateSeconds(seconds: string, blurred = true) {
+    this.invalidSeconds = false;
     this.seconds = seconds;
 
     const isValid = isSecondInputValid(this.seconds) && this.isValidLimit();
@@ -291,7 +290,7 @@ export class TimepickerComponent
       return;
     }
 
-    this._updateTime();
+    this._updateTime(blurred);
   }
 
   isValidLimit(): boolean {
@@ -303,7 +302,7 @@ export class TimepickerComponent
     }, this.max, this.min);
   }
 
-  _updateTime() {
+  _updateTime(blurred = true) {
     const _seconds = this.showSeconds ? this.seconds : void 0;
     const _minutes = this.showMinutes ? this.minutes : void 0;
     if (!isInputValid(this.hours, _minutes, _seconds, this.isPM())) {
@@ -313,14 +312,19 @@ export class TimepickerComponent
       return;
     }
 
-    this._store.dispatch(
-      this._timepickerActions.setTime({
-        hour: this.hours,
-        minute: this.minutes,
-        seconds: this.seconds,
-        isPM: this.isPM()
-      })
-    );
+    // We only dipatch this action if the user blurred the field.
+    // Otherwise, the store change would trigger _renderTime function
+    // while the user is typing which would be really annoying.
+    if (blurred) {
+      this._store.dispatch(
+        this._timepickerActions.setTime({
+          hour: this.hours,
+          minute: this.minutes,
+          seconds: this.seconds,
+          isPM: this.isPM()
+        })
+      );
+    }
   }
 
   toggleMeridian(): void {

--- a/src/timepicker/timepicker.utils.ts
+++ b/src/timepicker/timepicker.utils.ts
@@ -38,7 +38,7 @@ export function toNumber(value: string | number): number {
     return value;
   }
 
-  return +value;
+  return Number(value);
 }
 
 export function isNumber(value: string | number): value is number {

--- a/src/timepicker/timepicker.utils.ts
+++ b/src/timepicker/timepicker.utils.ts
@@ -39,7 +39,7 @@ export function toNumber(value: string | number): number {
     return value;
   }
 
-  return parseInt(value, dex);
+  return +value;
 }
 
 export function isNumber(value: string | number): value is number {

--- a/src/timepicker/timepicker.utils.ts
+++ b/src/timepicker/timepicker.utils.ts
@@ -1,6 +1,5 @@
 import { Time, TimepickerComponentState } from './timepicker.models';
 
-const dex = 10;
 const hoursPerDay = 24;
 const hoursPerDayHalf = 12;
 const minutesPerHour = 60;


### PR DESCRIPTION
* Manual inputs in timepicker input fields are now already validated on input, not only on blur
* Using the number pattern brings up the number keyboard on tablets
* Prevent timepicker now from resetting all validations for a new input, see https://github.com/valor-software/ngx-bootstrap/issues/5088
* Using "parseInt" allows input like '8j', this will result in '8' which might be confusing. I changed the conversion to use Number(...) so that these kind of values are also invalid.