### PR TITLE
fix(dsa-870): input fields should not be formatted while typing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smsdigital/ngx-bootstrap",
-  "version": "5.5.2",
+  "version": "5.5.3",
   "description": "Native Angular Bootstrap Components",
   "private": true,
   "scripts": {

--- a/src/package.json
+++ b/src/package.json
@@ -4,5 +4,5 @@
     "@angular/core": "*",
     "@angular/common": "*"
   },
-  "version": "5.5.2"
+  "version": "5.5.3"
 }

--- a/src/timepicker/timepicker.component.html
+++ b/src/timepicker/timepicker.component.html
@@ -34,7 +34,7 @@
     <td class="form-group" [class.has-error]="invalidHours">
       <input type="text" [class.is-invalid]="invalidHours"
              pattern="[0-9]*"
-             class="form-control text-center bs-timepicker-field"
+             class="form-control text-center bs-timepicker-field bs-timepicker-field-hours"
              [placeholder]="hoursPlaceholder"
              maxlength="2"
              [readonly]="readonlyInput||spinnersOnly"
@@ -52,7 +52,7 @@
     <td class="form-group" *ngIf="showMinutes" [class.has-error]="invalidMinutes">
       <input type="text" [class.is-invalid]="invalidMinutes"
              pattern="[0-9]*"
-             class="form-control text-center bs-timepicker-field"
+             class="form-control text-center bs-timepicker-field bs-timepicker-field-minutes"
              [placeholder]="minutesPlaceholder"
              maxlength="2"
              [readonly]="readonlyInput||spinnersOnly"
@@ -71,7 +71,7 @@
     <td class="form-group" *ngIf="showSeconds" [class.has-error]="invalidSeconds">
       <input type="text" [class.is-invalid]="invalidSeconds"
              pattern="[0-9]*"
-             class="form-control text-center bs-timepicker-field"
+             class="form-control text-center bs-timepicker-field bs-timepicker-field-seconds"
              [placeholder]="secondsPlaceholder"
              maxlength="2"
              [readonly]="readonlyInput||spinnersOnly"

--- a/src/timepicker/timepicker.component.ts
+++ b/src/timepicker/timepicker.component.ts
@@ -417,8 +417,12 @@ export class TimepickerComponent
       }
     }
 
-    this.hours = padNumber(_hours);
-    this.minutes = padNumber(_value.getMinutes());
-    this.seconds = padNumber(_value.getUTCSeconds());
+    const activeElementClasses = document.activeElement.classList;
+    const hoursActive = activeElementClasses.contains('bs-timepicker-field-hours');
+    const minutesActive = activeElementClasses.contains('bs-timepicker-field-minutes');
+    const secondsActive = activeElementClasses.contains('bs-timepicker-field-seconds');
+    this.hours = hoursActive ? `${_value.getHours()}` : padNumber(_hours);
+    this.minutes = minutesActive ? `${_value.getMinutes()}` : padNumber(_value.getMinutes());
+    this.seconds = secondsActive ? `${_value.getUTCSeconds()}` : padNumber(_value.getUTCSeconds());
   }
 }

--- a/src/timepicker/timepicker.utils.ts
+++ b/src/timepicker/timepicker.utils.ts
@@ -168,15 +168,15 @@ export function padNumber(value: number): string {
 }
 
 export function isHourInputValid(hours: string, isPM: boolean): boolean {
-  return !isNaN(parseHours(hours, isPM));
+  return hours.length > 0 && !isNaN(parseHours(hours, isPM));
 }
 
 export function isMinuteInputValid(minutes: string): boolean {
-  return !isNaN(parseMinutes(minutes));
+  return minutes.length > 0 && !isNaN(parseMinutes(minutes));
 }
 
 export function isSecondInputValid(seconds: string): boolean {
-  return !isNaN(parseSeconds(seconds));
+  return seconds.length > 0 && !isNaN(parseSeconds(seconds));
 }
 
 export function isInputLimitValid(diff: Time, max: Date, min: Date): boolean {


### PR DESCRIPTION
This fixes the annoying behaviour that input fields are formatted with leading zeroes while the user is still typing.
Also, before, empty fields were treated as valid and just silently updated with zero. 